### PR TITLE
Mount full poststart ConfigMap and restore lifecycle hook

### DIFF
--- a/templates/customer.yaml.template
+++ b/templates/customer.yaml.template
@@ -57,6 +57,10 @@ spec:
       containers:
       - name: sys-{{ name }}
         image: ghcr.io/sysarb/core-server:{{ version }}
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/usr/scripts/poststart/poststart.sh"]
         resources:
           requests:
             memory: "256Mi"  # Requesting 256Mi of memory
@@ -67,8 +71,7 @@ spec:
           mountPath: /app/appsettings-template.json
           subPath: appsettings.json
         - name: poststart
-          mountPath: /tmp/poststart-temp.sh
-          subPath: poststart.sh
+          mountPath: /usr/scripts/poststart
         env:
         - name: COMPlus_GCHeapHardLimitSegment
           value: "8589934592"
@@ -130,6 +133,7 @@ spec:
       - name: poststart
         configMap:
           name: coreserver-poststart
+          defaultMode: 0755
       - name: sql-restore-script
         configMap:
           name: coreserver-db-template-restore


### PR DESCRIPTION
## Summary
- Change poststart volume mount from single-file `subPath` to full directory at `/usr/scripts/poststart` so SQL files are accessible
- Add `defaultMode: 0755` so scripts are executable without the copy-to-tmp workaround
- Restore `lifecycle.postStart` hook that was removed in db7e748 — without it the poststart script was never invoked

## Depends on
- Sysarb/ansible PR (ConfigMap now includes 4 additional SQL data keys)

## Test plan
- [ ] Deploy updated ansible ConfigMap first
- [ ] Trigger action to regenerate coreserver manifests
- [ ] Verify poststart lifecycle hook is present in generated YAML
- [ ] Restart a coreserver pod and confirm poststart.sh executes (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)